### PR TITLE
Add other R instances if no other system R is found

### DIFF
--- a/R/rj.b.R
+++ b/R/rj.b.R
@@ -166,6 +166,10 @@ RjClass <- R6::R6Class(
                     return(list(path='/usr/local/bin/R'))
                 if (file.exists('/opt/local/bin/R'))
                     return(list(path='/opt/local/bin/R'))
+                else
+                    path <- system('which r')
+                    if (file.exists(path))
+                        return(list(path=path))
 
             } else if (os == 'Windows') {
 

--- a/R/rj.b.R
+++ b/R/rj.b.R
@@ -166,11 +166,13 @@ RjClass <- R6::R6Class(
                     return(list(path='/usr/local/bin/R'))
                 if (file.exists('/opt/local/bin/R'))
                     return(list(path='/opt/local/bin/R'))
-                else
-                    path <- system('which r')
-                    if (file.exists(path))
-                        return(list(path=path))
 
+                path <- try(system2('which', args='R', stdout=TRUE), silent = TRUE)
+                if (!inherits(path, "try-error")) {
+                    if (!is.na(path) && file.exists(path)) {
+                        return(list(path=path))
+                    }
+                }
             } else if (os == 'Windows') {
 
                 regHLM <- file.path("SOFTWARE", "R-core", "R64", fsep = "\\")


### PR DESCRIPTION
Hello!
Thank you so much for the package, it's amazing! I have though one issue with using system R on my machine.

This PR is a proposition to resolve my issue. I'm not experienced with coding in this ecosystem so please verify if that doesn't break anything. Thanks!

## Changes 
- Added a check for other R instances for OSX based operating systems if no previous paths returned the correct path

## Issue description
I have an issue with jamovi and Rj Editor + that the Rj cannot find system R instance - see the screenshot below:

![Screenshot 2024-03-08 at 12 45 53](https://github.com/jonathon-love/Rj/assets/11095999/80bac8dd-3a49-4dde-a57c-67fce1ce9fa8)

I'm using homebrew for installing packages, and I did so with R and RStudio. Paths of those tools are respectively:
```
/opt/homebrew/bin/r
/Applications/RStudio.app
```

I approached the problem by checking where the Rj package looks for R instances and as a first step I run `Sys.info()[['sysname']]` command on my R instance. It gave me the output `[1] "Darwin"` so I followed with analyzing the code in the respective if statement. From the code in the file `R/rj.b.R` I noticed that R instance is checked only in a couple places on my machine, and none of those places are valid for my case. But when I do `which r` in my terminal, I'm able to obtain the path for the R instance that is installed on my machine. 

I think adding that to the Rj Editor + will help others that have R installed on their machines but in non standard locations.


### The environment info:
```
Macbook Air M2
macOS: 14.2.1 (23C71)

jamovi: 2.4.14.0
Rj Editor +: 2.1.0
RStudio: 2023.12.1+402
R: 4.3.1
```