### PR TITLE
Add function openNew() for opening data sets in a new window

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rj
 Type: Package
 Title: Editor to run R code inside jamovi
-Version: 2.5.7
+Version: 2.5.8
 Author: Jonathon Love, Maurizio Agosti
 Maintainer: Jonathon Love <jon@thon.cc>
 Description: Provides an editor allowing you to enter R code, and analyse your

--- a/R/eval.R
+++ b/R/eval.R
@@ -177,3 +177,7 @@ eval <- function(script, data, echo, root, figWidth=400, figHeight=300, saveColu
 
     root
 }
+
+openNew <- function(data = NULL, title = "") {
+    jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl = title, rtnOut = FALSE)
+}

--- a/R/open.R
+++ b/R/open.R
@@ -1,7 +1,0 @@
-
-open <- function(data = NULL, title = "") {
-    jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl = title, rtnOut = FALSE)
-}
-
-newWin  <- open
-newSess <- open

--- a/R/open.R
+++ b/R/open.R
@@ -1,0 +1,7 @@
+
+open <- function(data = NULL, title = "") {
+    jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl = title, rtnOut = FALSE)
+}
+
+newWin  <- open
+newSess <- open

--- a/inst/remote.R
+++ b/inst/remote.R
@@ -5,6 +5,22 @@ if (Sys.info()['sysname'] == 'Windows') {
     Sys.setlocale('LC_ALL', 'en_US.UTF-8')
 }
 
+openNew <- function(data = NULL, title = "") {
+    if (requireNamespace("jmvReadWrite", quietly = TRUE)) {
+        if (packageVersion("jmvReadWrite") > '0.4.9') {
+            jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl = title, rtnOut = FALSE)
+        } else {
+            cat('To use the system R from jamovi, a newer version of jmvReadWrite (> 0.4.9) is required.')
+        }        
+    } else {
+        if (Sys.info()[['sysname']] %in% c("Darwin", "Windows")) {
+            cat("openNew() requires that jmvReadWrite is installed in your system R installation.")
+        } else {
+            cat("openNew() is only available under jamovi R on Linux / UNIX-like systems.")
+        }
+    }
+}
+
 reportError <- function(result) {
     error <- attr(result, 'condition')
     if ( ! is.null(error$message)) {

--- a/inst/remote.R
+++ b/inst/remote.R
@@ -16,7 +16,7 @@ openNew <- function(data = NULL, title = "") {
         if (Sys.info()[['sysname']] %in% c("Darwin", "Windows")) {
             cat("openNew() requires that jmvReadWrite is installed in your system R installation.")
         } else {
-            cat("openNew() is only available under jamovi R on Linux / UNIX-like systems.")
+            cat("openNew() is not available under 'system R' on Linux systems.")
         }
     }
 }

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -1,7 +1,7 @@
 ---
 title: Rj - Editor to run R code inside jamovi
 name: Rj
-version: 2.5.7
+version: 2.5.8
 jms: '1.0'
 usesNative: true
 minApp: 2.5.0
@@ -21,6 +21,7 @@ analyses:
     menuTitle: Rj Editor
     menuSubgroup: Rj
     arbitraryCode: true
+    arbitraryCode2: true
   - title: Rj Editor +
     name: Rjp
     ns: Rj
@@ -28,5 +29,6 @@ analyses:
     menuSubgroup: Rj
     menuTitle: Rj Editor +
     arbitraryCode: true
+    arbitraryCode2: true
 
 ...


### PR DESCRIPTION
Based upon a feature request by Marcello (in May 2024 if I remember correctly) I implemented an `openNew()` function in order to open the current dataset in a new window.

NB: Because of your comment to my previous PR, I now ensured and tested it using System R on both MacOS and Windows. For Linux, there is a note / warning to use the jamovi R. A requirement for using System R on Win and Mac is version 0.4.9 of jmvReadWrite which is accepted on CRAN and binaries should appear soon.

Here is some code for testing it (use any data set with more than three columns and more than three rows).
```
summary(data[1:3])
data[1, 1] <- NA
data[2, 2] <- NA
openNew(data, "Trial")
```

I suppose, the `arbitraryCode2: true` was automatically created by `jmvtools::install()`, it did not make that change.